### PR TITLE
fix: 🐛 iOS 15 render work around, UIKit interface, theme issues

### DIFF
--- a/Apps/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Apps/Examples/Examples.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		2C5225B7267CF7980089A062 /* Tests.json in Resources */ = {isa = PBXBuildFile; fileRef = 2C5225B6267CF7980089A062 /* Tests.json */; };
 		2C554AE22681189B007784D6 /* ARCardsRealityFileLoadingContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C554AE12681189B007784D6 /* ARCardsRealityFileLoadingContentView.swift */; };
 		2C554AE4268118E0007784D6 /* FileManager+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C554AE3268118E0007784D6 /* FileManager+Extensions.swift */; };
+		2C5CA835276B91BB000E0351 /* ARCardsAuthoringControllerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5CA834276B91BB000E0351 /* ARCardsAuthoringControllerView.swift */; };
 		2C9371282644D3C3001932D1 /* DownloadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9371272644D3C3001932D1 /* DownloadsView.swift */; };
 		2CC2A028268BFB8F0091C42B /* ARCardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC2A027268BFB8F0091C42B /* ARCardListView.swift */; };
 		2CCF965926824D9D00566523 /* ExampleRC.usdz in Resources */ = {isa = PBXBuildFile; fileRef = 2CCF965826824D9D00566523 /* ExampleRC.usdz */; };
@@ -54,6 +55,7 @@
 		2C5225B6267CF7980089A062 /* Tests.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Tests.json; sourceTree = "<group>"; };
 		2C554AE12681189B007784D6 /* ARCardsRealityFileLoadingContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARCardsRealityFileLoadingContentView.swift; sourceTree = "<group>"; };
 		2C554AE3268118E0007784D6 /* FileManager+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+Extensions.swift"; sourceTree = "<group>"; };
+		2C5CA834276B91BB000E0351 /* ARCardsAuthoringControllerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARCardsAuthoringControllerView.swift; sourceTree = "<group>"; };
 		2C9371272644D3C3001932D1 /* DownloadsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsView.swift; sourceTree = "<group>"; };
 		2CC2A027268BFB8F0091C42B /* ARCardListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARCardListView.swift; sourceTree = "<group>"; };
 		2CCF965826824D9D00566523 /* ExampleRC.usdz */ = {isa = PBXFileReference; lastKnownFileType = file.usdz; path = ExampleRC.usdz; sourceTree = "<group>"; };
@@ -105,6 +107,7 @@
 				2CC2A027268BFB8F0091C42B /* ARCardListView.swift */,
 				2C4A404526FEA11000D11A8F /* ARCardAuthoringContentView.swift */,
 				2C2C8860272C85F300E68413 /* ARCardsServiceView.swift */,
+				2C5CA834276B91BB000E0351 /* ARCardsAuthoringControllerView.swift */,
 			);
 			path = CardContentViews;
 			sourceTree = "<group>";
@@ -291,6 +294,7 @@
 				2CDD909826437D630076150D /* ExampleCardItem.swift in Sources */,
 				2CDD909B26437E7A0076150D /* Tests.swift in Sources */,
 				2C2C8861272C85F300E68413 /* ARCardsServiceView.swift in Sources */,
+				2C5CA835276B91BB000E0351 /* ARCardsAuthoringControllerView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Apps/Examples/Examples/ARCards/CardContentViews/ARCardListView.swift
+++ b/Apps/Examples/Examples/ARCards/CardContentViews/ARCardListView.swift
@@ -34,13 +34,18 @@ struct ARCardListView: View {
                 Text("JSON Decoding Example")
             }
             
+            NavigationLink(destination: ARCardsServiceView()) {
+                Text("Service Strategy - View Only")
+            }
+            
             NavigationLink(destination: ARCardAuthoringContentView()) {
                 Text("Card Authoring")
             }
             
-            NavigationLink(destination: ARCardsServiceView()) {
-                Text("Service Strategy - View Only")
+            NavigationLink(destination: SceneAuthoringWithUIKitView()) {
+                Text("Card Authoring - UIKit")
             }
+            
         }.navigationBarTitle("ARCards")
     }
 }

--- a/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsAuthoringControllerView.swift
+++ b/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsAuthoringControllerView.swift
@@ -60,7 +60,21 @@ class ARCardsAuthoringControllerVC: UIViewController {
         let sceneAuthoringController = SceneAuthoringController(title: "Annotations",
                                                                 serviceURL: URL(string: IntegrationTest.System.redirectURL)!,
                                                                 sapURLSession: self.sapURLSession,
-                                                                sceneIdentifier: SceneIdentifyingAttribute.id(IntegrationTest.TestData.sceneId))
+                                                                sceneIdentifier: SceneIdentifyingAttribute.id(IntegrationTest.TestData.sceneId),
+                                                                onSceneEdit: self.onSceneEdit)
         self.navigationController?.pushViewController(sceneAuthoringController, animated: true)
+    }
+    
+    func onSceneEdit(sceneEdit: SceneEditing) {
+        switch sceneEdit {
+        case .created(card: let card):
+            print("Created: \(card.title_)")
+        case .updated(card: let card):
+            print("Updated: \(card.title_)")
+        case .deleted(card: let card):
+            print("Deleted: \(card.title_)")
+        case .published(sceneID: let sceneID):
+            print("From SceneEdit:", sceneID)
+        }
     }
 }

--- a/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsAuthoringControllerView.swift
+++ b/Apps/Examples/Examples/ARCards/CardContentViews/ARCardsAuthoringControllerView.swift
@@ -1,0 +1,66 @@
+//
+//  ARCardsAuthoringControllerView.swift
+//  Examples
+//
+//  Created by O'Brien, Patrick on 12/16/21.
+//
+
+import FioriAR
+import SAPFoundation
+import SwiftUI
+import UIKit
+
+struct SceneAuthoringWithUIKitView: View {
+    var body: some View {
+        SceneAuthoringControllerContainer()
+            .navigationBarTitle("Using UIKit")
+    }
+}
+
+// Implemented just to present SceneAuthoringController in Test App which is SwiftUI based
+struct SceneAuthoringControllerContainer: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> ARCardsAuthoringControllerVC {
+        ARCardsAuthoringControllerVC()
+    }
+    
+    func updateUIViewController(_ uiViewController: ARCardsAuthoringControllerVC, context: Context) {}
+}
+
+class ARCardsAuthoringControllerVC: UIViewController {
+    var presentSceneAuthoring: UIButton!
+    
+    private var sapURLSession = SAPURLSession.createOAuthURLSession(
+        clientID: IntegrationTest.System.clientID,
+        authURL: IntegrationTest.System.authURL,
+        redirectURL: IntegrationTest.System.redirectURL,
+        tokenURL: IntegrationTest.System.tokenURL
+    )
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.presentSceneAuthoring = UIButton()
+        self.presentSceneAuthoring.setTitle("Present Scene Authoring", for: .normal)
+        self.presentSceneAuthoring.setTitleColor(.white, for: .normal)
+        self.presentSceneAuthoring.layer.cornerRadius = 10
+        self.presentSceneAuthoring.backgroundColor = .systemBlue
+        
+        view.addSubview(self.presentSceneAuthoring)
+        self.presentSceneAuthoring.translatesAutoresizingMaskIntoConstraints = false
+        self.presentSceneAuthoring.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        self.presentSceneAuthoring.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -100).isActive = true
+        self.presentSceneAuthoring.widthAnchor.constraint(equalToConstant: 250).isActive = true
+        self.presentSceneAuthoring.heightAnchor.constraint(equalToConstant: 60).isActive = true
+        self.presentSceneAuthoring.addTarget(self, action: #selector(self.presentSceneAuthoringAction), for: .touchUpInside)
+    }
+    
+    // Use navigationController?.pushViewController()
+    // Modal presenting not supported
+    @objc func presentSceneAuthoringAction(sender: UIButton) {
+        let sceneAuthoringController = SceneAuthoringController(title: "Annotations",
+                                                                serviceURL: URL(string: IntegrationTest.System.redirectURL)!,
+                                                                sapURLSession: self.sapURLSession,
+                                                                sceneIdentifier: SceneIdentifyingAttribute.id(IntegrationTest.TestData.sceneId))
+        self.navigationController?.pushViewController(sceneAuthoringController, animated: true)
+    }
+}

--- a/Apps/Examples/Examples/ContentView.swift
+++ b/Apps/Examples/Examples/ContentView.swift
@@ -15,13 +15,13 @@ struct ContentView: View {
                 NavigationLink(destination: ARCardListView()) {
                     Text("ARCards")
                 }
+                
+                NavigationLink(destination: ARCardAuthoringContentView()) {
+                    Text("Card Authoring")
+                }
 
                 NavigationLink(destination: DownloadsView()) {
                     Text("Download Image Anchors")
-                }
-
-                NavigationLink(destination: ARCardAuthoringContentView()) {
-                    Text("Card Authoring")
                 }
             }.navigationBarTitle("Examples")
         }.navigationViewStyle(StackNavigationViewStyle())

--- a/Sources/FioriAR/ARCards/ViewModels/ARAnnotationViewModel.swift
+++ b/Sources/FioriAR/ARCards/ViewModels/ARAnnotationViewModel.swift
@@ -257,4 +257,12 @@ open class ARAnnotationViewModel<CardItem: CardItemModel>: NSObject, ObservableO
             self.anchorPosition = self.getAnchorPosition(for: arkitAnchor)
         }
     }
+    
+    // Work around for iOS 15 rendering issue
+    /// Updates the  anchorEntities when the underlying ARAnchors update
+    public func session(_ session: ARSession, didUpdate anchors: [ARAnchor]) {
+        if let arAnchor = anchors.first, let anchorEntity = arManager.sceneAnchors[arAnchor.identifier] {
+            anchorEntity.setTransformMatrix(arAnchor.transform, relativeTo: nil)
+        }
+    }
 }

--- a/Sources/FioriAR/ARCards/ViewModels/ARManager.swift
+++ b/Sources/FioriAR/ARCards/ViewModels/ARManager.swift
@@ -16,6 +16,10 @@ public class ARManager {
 
     /// The Root Entity with the entities that back the real world positions of the Annotations as children
     public var sceneRoot: Entity?
+    
+    // Work around for iOS 15 rendering issue
+    /// Retain AnchorIDs to update AnchorEntity transforms
+    var sceneAnchors: [AnchorID: AnchorEntity] = [:]
 
     var worldMap: ARWorldMap?
     var referenceImages: Set<ARReferenceImage> = []
@@ -89,9 +93,10 @@ public class ARManager {
 
     internal func addARKitAnchor(for anchor: ARAnchor, children: [Entity] = []) {
         #if !targetEnvironment(simulator)
-            let anchorEntity = AnchorEntity(anchor: anchor)
+            let anchorEntity = AnchorEntity(world: anchor.transform) // Work around for iOS 15 rendering issue, ideally use ARAnchor(anchor:)
             children.forEach { anchorEntity.addChild($0) }
             self.addAnchor(anchor: anchorEntity)
+            self.sceneAnchors[anchor.identifier] = anchorEntity
         #endif
     }
 

--- a/Sources/FioriAR/ARCards/Views/Authoring/AnchorImageFormView.swift
+++ b/Sources/FioriAR/ARCards/Views/Authoring/AnchorImageFormView.swift
@@ -9,7 +9,7 @@ import ARKit
 import SwiftUI
 
 struct AnchorImageFormView: View {
-    @Environment(\.verticalSizeClass) var verticalSizeClass
+    @Environment(\.safeAreaInsets) var safeAreaInsets
     
     @Binding var anchorImage: UIImage?
     @Binding var physicalWidth: String
@@ -186,7 +186,8 @@ struct AnchorImageFormView: View {
                 })
                     .padding(.bottom, 32)
             }
-            .padding(.horizontal, verticalSizeClass == .compact ? 40 : 0)
+            .padding(.leading, safeAreaInsets.leading)
+            .padding(.trailing, safeAreaInsets.trailing)
         }
         .onTapGesture(perform: hideKeyboard)
         .background(Color.preferredColor(.primaryGroupedBackground, background: .lightConstant))

--- a/Sources/FioriAR/ARCards/Views/Authoring/CardFormView.swift
+++ b/Sources/FioriAR/ARCards/Views/Authoring/CardFormView.swift
@@ -22,6 +22,7 @@ public enum SceneEditing {
 }
 
 struct CardFormView: View {
+    @Environment(\.safeAreaInsets) var safeAreaInsets
     @Environment(\.verticalSizeClass) var verticalSizeClass
     @Environment(\.presentationMode) var presentationMode
     @Environment(\.onSceneEdit) var onSceneEdit
@@ -94,6 +95,8 @@ struct CardFormView: View {
                                      .foregroundColor(Color.preferredColor(.primaryLabel, background: .lightConstant))
                              }
                          })
+                .padding(.leading, safeAreaInsets.leading)
+                .padding(.trailing, safeAreaInsets.trailing)
                 .background(Color.preferredColor(.primaryGroupedBackground, background: .lightConstant))
 
             AdaptiveStack {
@@ -127,6 +130,8 @@ struct CardFormView: View {
                                     presentationMode.wrappedValue.dismiss()
                                 })
             }
+            .padding(.leading, safeAreaInsets.leading)
+            .padding(.trailing, safeAreaInsets.trailing)
         }
         .onChange(of: actionContentText) { newValue in
             icon = newValue.isEmpty ? nil : "link"
@@ -520,7 +525,6 @@ private struct AdaptiveStack<Content>: View where Content: View {
             HStack {
                 content
             }
-            .padding(.horizontal, 40)
         } else {
             VStack {
                 content

--- a/Sources/FioriAR/ARCards/Views/Authoring/CardFormView.swift
+++ b/Sources/FioriAR/ARCards/Views/Authoring/CardFormView.swift
@@ -85,13 +85,13 @@ struct CardFormView: View {
                          leftBarLabel: {
                              Image(systemName: "xmark")
                                  .font(.system(size: 22))
-                                 .foregroundColor(Color.preferredColor(.primaryLabel))
+                                 .foregroundColor(Color.preferredColor(.primaryLabel, background: .lightConstant))
                          },
                          rightBarLabel: {
                              if let _ = currentCardID {
                                  Image(systemName: "trash")
                                      .font(.system(size: 22))
-                                     .foregroundColor(Color.preferredColor(.primaryLabel))
+                                     .foregroundColor(Color.preferredColor(.primaryLabel, background: .lightConstant))
                              }
                          })
                 .background(Color.preferredColor(.primaryGroupedBackground, background: .lightConstant))

--- a/Sources/FioriAR/ARCards/Views/Authoring/MarkerPositionFlow/MarkerPositionFlowView.swift
+++ b/Sources/FioriAR/ARCards/Views/Authoring/MarkerPositionFlow/MarkerPositionFlowView.swift
@@ -108,6 +108,7 @@ struct MarkerPositioningFlowView<Scan: View, Card: View, Marker: View, CardItem>
             }
         }
         .edgesIgnoringSafeArea(.all)
+        .preferredColorScheme(.dark)
         .navigationBarTitle("")
         .navigationBarHidden(true)
         .overlay(BackButton(flowState: flowState, onAction: dismiss), alignment: .topLeading)

--- a/Sources/FioriAR/ARCards/Views/Authoring/SceneAuthoringController.swift
+++ b/Sources/FioriAR/ARCards/Views/Authoring/SceneAuthoringController.swift
@@ -15,26 +15,43 @@ import SwiftUI
 
  ## Usage
  ```
- @objc func launchSceneAuthoring(sender: UIButton) {
+ // Use navigationController?.pushViewController()
+ // Modal presenting not supported
+ @objc func presentSceneAuthoringAction(sender: UIButton) {
      let sceneAuthoringController = SceneAuthoringController(title: "Annotations",
-                                                             serviceURL:  URL(string: IntegrationTest.System.redirectURL)!,
-                                                             sapURLSession: sapURLSession,
-                                                             sceneIdentifier: SceneIdentifyingAttribute.id(IntegrationTest.TestData.sceneId))
+                                                             serviceURL: URL(string: IntegrationTest.System.redirectURL)!,
+                                                             sapURLSession: self.sapURLSession,
+                                                             sceneIdentifier: SceneIdentifyingAttribute.id(IntegrationTest.TestData.sceneId),
+                                                             onSceneEdit: onSceneEdit)
      self.navigationController?.pushViewController(sceneAuthoringController, animated: true)
+ }
+ 
+ func onSceneEdit(sceneEdit: SceneEditing) {
+     switch sceneEdit {
+     case .created(card: let card):
+         print("Created: \(card.title_)")
+     case .updated(card: let card):
+         print("Updated: \(card.title_)")
+     case .deleted(card: let card):
+         print("Deleted: \(card.title_)")
+     case .published(sceneID: let sceneID):
+         print("From SceneEdit:", sceneID)
+     }
  }
  ```
  */
-public class SceneAuthoringController: UIHostingController<SceneAuthoringView> {
+public class SceneAuthoringController: UIHostingController<AnyView> {
     /// Initializer
     /// - Parameters:
     ///   - title: Title of the Scene
-    ///   - serviceURL: SAPURLSession to provide credentials to Mobile Services
-    ///   - sapURLSession: If nil then a new scene is created.
+    ///   - serviceURL: Mobile Services Server URL for your application
+    ///   - sapURLSession: SAPURLSession to provide credentials to Mobile Services
     ///   - sceneIdentifier: Pass nil to create a new scene. To update a a scene you have to supply the identifier used in SAP Mobile Servcies to identify the scene.
-    public init(title: String, serviceURL: URL, sapURLSession: SAPURLSession, sceneIdentifier: SceneIdentifyingAttribute? = nil) {
-        super.init(rootView: SceneAuthoringView(title: title, serviceURL: serviceURL, sapURLSession: sapURLSession, sceneIdentifier: sceneIdentifier))
+    ///   - onSceneEdit: called when scene was published or a card has locally been created, updated, or deleted
+    public init(title: String, serviceURL: URL, sapURLSession: SAPURLSession, sceneIdentifier: SceneIdentifyingAttribute? = nil, onSceneEdit: ((SceneEditing) -> Void)?) {
+        super.init(rootView: AnyView(SceneAuthoringView(title: title, serviceURL: serviceURL, sapURLSession: sapURLSession, sceneIdentifier: sceneIdentifier).onSceneEdit(perform: onSceneEdit ?? { _ in })))
     }
-    
+
     @available(*, unavailable)
     @objc dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/Sources/FioriAR/ARCards/Views/Authoring/SceneAuthoringController.swift
+++ b/Sources/FioriAR/ARCards/Views/Authoring/SceneAuthoringController.swift
@@ -1,0 +1,52 @@
+//
+//  SceneAuthoringController.swift
+//
+//
+//  Created by O'Brien, Patrick on 12/16/21.
+//
+
+import SAPFoundation
+import SwiftUI
+
+/**
+ Provides the flow for authoring an AR Annotation Scene using UIKit. Used to create the content for the cards, select an anchor Image, and position the entities in their real world locations. Publishing the scene using Mobile Services with an SAPURLSession.
+ The onSceneEdit modifier provides a callback on editing events. When a scene was published, i.e. created or updated in SAP Mobile Services, then `.published(sceneID)` is called and returns the technical id of the scene.
+ Note: Push onto a navigation stack, modal presenting not supported
+
+ ## Usage
+ ```
+ @objc func launchSceneAuthoring(sender: UIButton) {
+     let sceneAuthoringController = SceneAuthoringController(title: "Annotations",
+                                                             serviceURL:  URL(string: IntegrationTest.System.redirectURL)!,
+                                                             sapURLSession: sapURLSession,
+                                                             sceneIdentifier: SceneIdentifyingAttribute.id(IntegrationTest.TestData.sceneId))
+     self.navigationController?.pushViewController(sceneAuthoringController, animated: true)
+ }
+ ```
+ */
+public class SceneAuthoringController: UIHostingController<SceneAuthoringView> {
+    /// Initializer
+    /// - Parameters:
+    ///   - title: Title of the Scene
+    ///   - serviceURL: SAPURLSession to provide credentials to Mobile Services
+    ///   - sapURLSession: If nil then a new scene is created.
+    ///   - sceneIdentifier: Pass nil to create a new scene. To update a a scene you have to supply the identifier used in SAP Mobile Servcies to identify the scene.
+    public init(title: String, serviceURL: URL, sapURLSession: SAPURLSession, sceneIdentifier: SceneIdentifyingAttribute? = nil) {
+        super.init(rootView: SceneAuthoringView(title: title, serviceURL: serviceURL, sapURLSession: sapURLSession, sceneIdentifier: sceneIdentifier))
+    }
+    
+    @available(*, unavailable)
+    @objc dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override public func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.setNavigationBarHidden(true, animated: true)
+    }
+    
+    override public func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.navigationController?.setNavigationBarHidden(false, animated: true)
+    }
+}

--- a/Sources/FioriAR/ARCards/Views/Authoring/SceneAuthoringView.swift
+++ b/Sources/FioriAR/ARCards/Views/Authoring/SceneAuthoringView.swift
@@ -58,7 +58,7 @@ public struct SceneAuthoringView: View {
         self.title = title
         let networkingAPI = ARCardsNetworkingService(sapURLSession: sapURLSession, baseURL: serviceURL.absoluteString)
         _authoringViewModel = StateObject(wrappedValue: SceneAuthoringModel(networkingAPI: networkingAPI, sceneIdentifier: sceneIdentifier))
-        _arViewModel = StateObject(wrappedValue: ARAnnotationViewModel<CodableCardItem>(arManager: ARManager(canBeFatal: false))) // TODO: Back to Fatal
+        _arViewModel = StateObject(wrappedValue: ARAnnotationViewModel<CodableCardItem>())
     }
 
     /// SwiftUI's view body
@@ -133,8 +133,8 @@ public struct SceneAuthoringView: View {
                 label: { EmptyView() })
         )
         .navigationBarHidden(hideNavBar)
-        .preferredColorScheme(.light)
         .navigationBarTitle("")
+        .preferredColorScheme(.light)
         .overlay(startARButton, alignment: .bottom)
         .edgesIgnoringSafeArea(.all)
         .onAppear(perform: authoringViewModel.populateAttachmentView)

--- a/Sources/FioriAR/ARCards/Views/Authoring/SceneAuthoringView.swift
+++ b/Sources/FioriAR/ARCards/Views/Authoring/SceneAuthoringView.swift
@@ -51,8 +51,8 @@ public struct SceneAuthoringView: View {
     /// Initializer
     /// - Parameters:
     ///   - title: Title of the Scene
-    ///   - serviceURL: SAPURLSession to provide credentials to Mobile Services
-    ///   - sapURLSession: If nil then a new scene is created.
+    ///   - serviceURL: Server URL for your application in SAP Mobile Services
+    ///   - sapURLSession: SAPURLSession to provide credentials to Mobile Services
     ///   - sceneIdentifier: Pass nil to create a new scene. To update a a scene you have to supply the identifier used in SAP Mobile Servcies to identify the scene.
     public init(title: String, serviceURL: URL, sapURLSession: SAPURLSession, sceneIdentifier: SceneIdentifyingAttribute? = nil) {
         self.title = title
@@ -86,8 +86,8 @@ public struct SceneAuthoringView: View {
                                  .font(.fiori(forTextStyle: .body).weight(.bold))
                                  .foregroundColor(Color.preferredColor(authoringViewModel.isSyncValidated ? .tintColor : .separator, background: .lightConstant))
                          })
-                .background(Color.white)
                 .padding(.bottom, 6)
+                .background(Color.white)
 
             VStack(spacing: 0) {
                 TabbedView(currentTab: $authoringViewModel.currentTab, leftTabTitle: "Cards".localizedString, rightTabTitle: "Image Anchor".localizedString)
@@ -115,7 +115,6 @@ public struct SceneAuthoringView: View {
                     AnchorImageTabView(anchorImage: $authoringViewModel.anchorImage, physicalWidth: $authoringViewModel.physicalWidth, onDismiss: { authoringViewModel.validateSync() })
                 }
             }
-            .padding(.horizontal, verticalSizeClass == .compact ? 40 : 0)
             .background(Color.white)
         }
         .background(
@@ -136,7 +135,7 @@ public struct SceneAuthoringView: View {
         .navigationBarTitle("")
         .preferredColorScheme(.light)
         .overlay(startARButton, alignment: .bottom)
-        .edgesIgnoringSafeArea(.all)
+        .edgesIgnoringSafeArea(.top)
         .onAppear(perform: authoringViewModel.populateAttachmentView)
         .fullScreenCover(isPresented: $isARExperiencePresented) {
             MarkerPositioningFlowView(arModel: arViewModel,
@@ -163,7 +162,7 @@ public struct SceneAuthoringView: View {
             Text("Go to AR Scene", bundle: .fioriAR)
                 .font(.fiori(forTextStyle: .body).weight(.bold))
                 .foregroundColor(Color.preferredColor(authoringViewModel.validatedAR() ? .secondaryGroupedBackground : .separator, background: .lightConstant))
-                .frame(width: verticalSizeClass == .compact ? 702 : 351, height: 54)
+                .frame(maxWidth: .infinity, maxHeight: 54)
                 .background(
                     RoundedRectangle(cornerRadius: 16)
                         .fill(Color.white)
@@ -179,7 +178,8 @@ public struct SceneAuthoringView: View {
                 )
         })
             .disabled(!authoringViewModel.validatedAR())
-            .padding(.bottom, verticalSizeClass == .compact ? 29 : 50)
+            .padding(.horizontal, 12)
+            .padding(.bottom, 29)
     }
 
     func startAR() {

--- a/Sources/FioriAR/ARCards/Views/Card/CardView.swift
+++ b/Sources/FioriAR/ARCards/Views/Card/CardView.swift
@@ -235,14 +235,16 @@ public extension CardView where
          isSelected: Bool)
     {
         var image: Image?
+        var contentMode: SwiftUI.ContentMode?
         if let data = detailImage, let uiImage = UIImage(data: data) {
             image = Image(uiImage: uiImage)
+            contentMode = uiImage.size.width < 214 || uiImage.size.height < 93 ? .fit : .fill
         }
         
         self.id = id
         self._title = Text(title)
         self._subtitle = subtitle != nil ? ViewBuilder.buildEither(first: Text(subtitle!)) : ViewBuilder.buildEither(second: EmptyView())
-        self._detailImage = image != nil ? ViewBuilder.buildEither(first: ImagePreview(preview: image!)) : ViewBuilder.buildEither(second: DefaultIcon(iconString: icon))
+        self._detailImage = (image != nil && contentMode != nil) ? ViewBuilder.buildEither(first: ImagePreview(preview: image!, contentMode: contentMode!)) : ViewBuilder.buildEither(second: DefaultIcon(iconString: icon))
         self._actionText = actionText != nil ? ViewBuilder.buildEither(first: Text(actionText!)) : ViewBuilder.buildEither(second: EmptyView())
         self.actionContentURL = actionContentURL
         self.action = action
@@ -277,41 +279,26 @@ public struct DefaultIcon: View {
 /// SwiftUI view to preview an image
 public struct ImagePreview: View {
     private var image: Image
-    @State private var size: CGSize = .zero
+    private var contentMode: SwiftUI.ContentMode
 
     /// Initializer
     /// - Parameter preview: image to be displayed
-    public init(preview: Image) {
+    /// - Parameter contentMode: contentMode of the image
+    public init(preview: Image, contentMode: SwiftUI.ContentMode) {
         self.image = preview
+        self.contentMode = contentMode
     }
-
+    
     /// SwiftUI’s view body
     public var body: some View {
-        GeometryReader { geo in
-            ZStack {
-                image
-                    .readSize { size in
-                        self.size = size
-                    }
-                    .frame(width: geo.size.width, height: geo.size.height)
-                
-                image
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .blur(radius: 10)
-                    .frame(width: geo.size.width, height: geo.size.height)
-
-                if size.width < geo.size.width, size.height < geo.size.height {
-                    image
-                        .resizable()
-                        .scaledToFit()
-                } else {
-                    image
-                        .resizable()
-                        .scaledToFill()
-                }
-            }
-            .frame(width: geo.size.width, height: geo.size.height)
+        ZStack {
+            image
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .blur(radius: 10)
+            image
+                .resizable()
+                .aspectRatio(contentMode: contentMode)
         }
     }
 }

--- a/Sources/FioriAR/ARCards/Views/Card/CardView.swift
+++ b/Sources/FioriAR/ARCards/Views/Card/CardView.swift
@@ -284,7 +284,7 @@ public struct ImagePreview: View {
     /// Initializer
     /// - Parameter preview: image to be displayed
     /// - Parameter contentMode: contentMode of the image
-    public init(preview: Image, contentMode: SwiftUI.ContentMode) {
+    public init(preview: Image, contentMode: SwiftUI.ContentMode = .fill) {
         self.image = preview
         self.contentMode = contentMode
     }

--- a/Sources/FioriAR/ARCards/Views/Components/TitleBarView.swift
+++ b/Sources/FioriAR/ARCards/Views/Components/TitleBarView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TitleBarView<LeftBarLabel, RightBarLabel>: View where LeftBarLabel: View, RightBarLabel: View {
-    @Environment(\.verticalSizeClass) var verticalSizeClass
+    @Environment(\.safeAreaInsets) var safeAreaInsets
     
     var title: String
     
@@ -57,9 +57,8 @@ struct TitleBarView<LeftBarLabel, RightBarLabel>: View where LeftBarLabel: View,
                     .disabled(rightDisabled)
             }
         }
+        .frame(height: 52)
+        .padding(.top, safeAreaInsets.top)
         .padding(.horizontal, 16)
-        .frame(minHeight: 52)
-        .padding(.top, verticalSizeClass == .compact ? 0 : 44)
-        .padding(.horizontal, verticalSizeClass == .compact ? 40 : 0)
     }
 }

--- a/Sources/FioriAR/Utils/Environment+Extensions.swift
+++ b/Sources/FioriAR/Utils/Environment+Extensions.swift
@@ -45,6 +45,10 @@ public extension EnvironmentValues {
         get { self[SceneEditKey.self] }
         set { self[SceneEditKey.self] = newValue }
     }
+    
+    var safeAreaInsets: EdgeInsets {
+        self[SafeAreaInsetsKey.self]
+    }
 }
 
 struct TitleModifierKey: EnvironmentKey {
@@ -69,4 +73,8 @@ struct CarouselOptionsKey: EnvironmentKey {
 
 struct SceneEditKey: EnvironmentKey {
     public static let defaultValue: (SceneEditing) -> Void = { _ in }
+}
+
+struct SafeAreaInsetsKey: EnvironmentKey {
+    public static var defaultValue: EdgeInsets { (UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.safeAreaInsets ?? .zero).insets }
 }

--- a/Sources/FioriAR/Utils/UIEdgeInset+Extensions.swift
+++ b/Sources/FioriAR/Utils/UIEdgeInset+Extensions.swift
@@ -1,0 +1,12 @@
+//
+//  UIEdgeInsets.swift
+//
+//
+//  Created by O'Brien, Patrick on 12/16/21.
+//
+
+import SwiftUI
+
+extension UIEdgeInsets {
+    var insets: EdgeInsets { EdgeInsets(top: top, leading: left, bottom: bottom, trailing: right) }
+}


### PR DESCRIPTION
1. RealityKit Rendering Issue introduced in iOS 15. Apple responded with work around:
    - Issue: 
      - `AnchorEntity(anchor: arAnchor)` initializer has unexpected behavior. 
    - Work Around:
       - Use `AnchorEntity(world: arAnchor.transform)`
       - Retain arAnchor identifier with associated AnchorEntity
       - Use ARSessionDelegate didUpdate ARAnchors to update the AnchorEntities transform when underlying ARAnchor updates

2. Subclass UIHostingController to set the NavigationBar's visibility on push and pop when interfacing with UIKit

3. Theming fix
