### PR TITLE
feat: 🎸 Use PHPicker for image selection

### DIFF
--- a/Apps/Examples/Examples/Info.plist
+++ b/Apps/Examples/Examples/Info.plist
@@ -22,12 +22,10 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Save Image Anchors to Photo Library</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Use Camera for AR Examples</string>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>To save image anchor to library</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>To show the file name of the picture for anchor image</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Sources/FioriAR/ARCards/Views/Authoring/AnchorImageFormView.swift
+++ b/Sources/FioriAR/ARCards/Views/Authoring/AnchorImageFormView.swift
@@ -21,7 +21,7 @@ struct AnchorImageFormView: View {
     
     @State private var actionSheetPresented = false
     @State private var pickerPresented = false
-    @State private var pickerSource: UIImagePickerController.SourceType = .photoLibrary
+    @State private var pickerSource: ImagePickerSource = .photoLibrary
     
     @State private var physicalWidthValidationText = ""
     @State private var imageValidationText = ""
@@ -205,7 +205,7 @@ struct AnchorImageFormView: View {
                         }), .cancel()])
         }
         .fullScreenCover(isPresented: $pickerPresented) {
-            ImagePickerView(uiImage: $internalAnchorImage, fileName: $internalImageName, sourceType: pickerSource)
+            PickerSelectionView(uiImage: $internalAnchorImage, imageSource: pickerSource)
                 .edgesIgnoringSafeArea(.all)
         }
     }

--- a/Sources/FioriAR/ARCards/Views/Authoring/CardFormView.swift
+++ b/Sources/FioriAR/ARCards/Views/Authoring/CardFormView.swift
@@ -192,11 +192,11 @@ private struct CardDetailsView: View {
     @Binding var actionButtonToggle: Bool
     @Binding var coverImageToggle: Bool
 
-    @State var actionSheetPresented = false
-    @State var pickerPresented = false
-    @State var pickerSource: UIImagePickerController.SourceType = .photoLibrary
+    @State private var actionSheetPresented = false
+    @State private var pickerPresented = false
+    @State private var pickerSource: ImagePickerSource = .photoLibrary
 
-    @State var imagePickerData: Data? = nil
+    @State private var pickedUIImage: UIImage? = nil
 
     var isUpdate: Bool
     var editCardAction: (() -> Void)?
@@ -268,11 +268,11 @@ private struct CardDetailsView: View {
                         }), .cancel()])
         }
         .fullScreenCover(isPresented: $pickerPresented) {
-            ImagePickerView(imageData: $imagePickerData, sourceType: pickerSource)
+            PickerSelectionView(uiImage: $pickedUIImage, imageSource: pickerSource)
                 .edgesIgnoringSafeArea(.all)
         }
-        .onChange(of: imagePickerData) { newValue in
-            guard let imageData = newValue else { return }
+        .onChange(of: pickedUIImage) { newValue in
+            guard let uiImage = newValue, let imageData = uiImage.pngData() else { return }
             if self.detailImage == nil {
                 self.detailImage = CardImage(data: imageData)
             } else {

--- a/Sources/FioriAR/ARCards/Views/Components/ImageCameraPickerView.swift
+++ b/Sources/FioriAR/ARCards/Views/Components/ImageCameraPickerView.swift
@@ -1,0 +1,50 @@
+//
+//  ImagePickerView.swift
+//
+//
+//  Created by Diaz, Ernesto on 9/17/21.
+//
+
+import Photos
+import SwiftUI
+import UIKit
+
+struct ImageCameraPickerView: UIViewControllerRepresentable {
+    @Environment(\.presentationMode) var isPresented
+    
+    @Binding var uiImage: UIImage?
+    
+    init(uiImage: Binding<UIImage?>) {
+        self._uiImage = uiImage
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(imagePicker: self)
+    }
+    
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let cameraPicker = UIImagePickerController()
+        cameraPicker.sourceType = .camera
+        cameraPicker.delegate = context.coordinator
+        return cameraPicker
+    }
+    
+    func updateUIViewController(_ picker: UIImagePickerController, context: Context) {}
+    
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        var imagePicker: ImageCameraPickerView
+        
+        init(imagePicker: ImageCameraPickerView) {
+            self.imagePicker = imagePicker
+        }
+        
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+            if let cameraImage = info[.originalImage] as? UIImage, let rotatedImage = cameraImage.resize(to: 1) {
+                self.imagePicker.uiImage = rotatedImage
+            }
+            self.imagePicker.isPresented.wrappedValue.dismiss()
+        }
+    }
+
+    typealias UIViewControllerType = UIImagePickerController
+}

--- a/Sources/FioriAR/ARCards/Views/Components/ImagePickerView.swift
+++ b/Sources/FioriAR/ARCards/Views/Components/ImagePickerView.swift
@@ -5,73 +5,58 @@
 //  Created by Diaz, Ernesto on 9/17/21.
 //
 
-import Photos
+import PhotosUI
 import SwiftUI
 import UIKit
 
 struct ImagePickerView: UIViewControllerRepresentable {
     @Environment(\.presentationMode) var isPresented
     
-    @Binding var image: Image?
     @Binding var uiImage: UIImage?
-    @Binding var imageData: Data?
-    @Binding var fileName: String?
     
-    var sourceType: UIImagePickerController.SourceType
-    
-    init(image: Binding<Image?> = .constant(nil),
-         uiImage: Binding<UIImage?> = .constant(nil),
-         imageData: Binding<Data?> = .constant(nil),
-         fileName: Binding<String?> = .constant(nil),
-         sourceType: UIImagePickerController.SourceType)
-    {
-        self._image = image
+    init(uiImage: Binding<UIImage?>) {
         self._uiImage = uiImage
-        self._imageData = imageData
-        self._fileName = fileName
-        self.sourceType = sourceType
     }
     
     func makeCoordinator() -> Coordinator {
-        Coordinator(picker: self)
+        Coordinator(imagePicker: self)
     }
     
-    func makeUIViewController(context: Context) -> some UIViewController {
-        let imagePicker = UIImagePickerController()
-        imagePicker.sourceType = self.sourceType
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var config = PHPickerConfiguration()
+        config.filter = .images
+        config.selectionLimit = 1
+        config.preferredAssetRepresentationMode = .current
+        
+        let imagePicker = PHPickerViewController(configuration: config)
         imagePicker.delegate = context.coordinator
+
         return imagePicker
     }
     
-    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
-}
-
-class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
-    var picker: ImagePickerView
+    func updateUIViewController(_ imagePicker: PHPickerViewController, context: Context) {}
     
-    init(picker: ImagePickerView) {
-        self.picker = picker
-    }
-    
-    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-        guard let pickedImage = info[.originalImage] as? UIImage,
-              let resized = pickedImage.resize(to: 0.50) else { return }
-        // Large images causes unexpected layout issues in SwiftUI
-        let uiImage = pickedImage.size.height * pickedImage.scale > 2000 ? resized : pickedImage
-        self.picker.uiImage = uiImage
-        self.picker.image = Image(uiImage: uiImage)
-        self.picker.imageData = uiImage.pngData()
+    class Coordinator: NSObject, UINavigationControllerDelegate, PHPickerViewControllerDelegate {
+        var imagePicker: ImagePickerView
         
-        self.picker.isPresented.wrappedValue.dismiss()
+        init(imagePicker: ImagePickerView) {
+            self.imagePicker = imagePicker
+        }
+        
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            if let itemProvider = results.first?.itemProvider, itemProvider.canLoadObject(ofClass: UIImage.self) {
+                itemProvider.loadObject(ofClass: UIImage.self) { object, _ in
+                    // Large images causes unexpected layout issues in SwiftUI
+                    if let pickedImage = object as? UIImage,
+                       let resizedImage = (pickedImage.size.height * pickedImage.scale) > 2000 ? pickedImage.resize(to: 0.5) : pickedImage
+                    {
+                        self.imagePicker.uiImage = resizedImage
+                    }
+                }
+            }
+            self.imagePicker.isPresented.wrappedValue.dismiss()
+        }
     }
-}
 
-private extension UIImage {
-    func resize(to percent: CGFloat) -> UIImage? {
-        let newSize = CGSize(width: self.size.width * percent, height: self.size.height * percent)
-        UIGraphicsBeginImageContextWithOptions(newSize, true, 1.0)
-        self.draw(in: CGRect(origin: .zero, size: newSize))
-        defer { UIGraphicsEndImageContext() }
-        return UIGraphicsGetImageFromCurrentImageContext()
-    }
+    typealias UIViewControllerType = PHPickerViewController
 }

--- a/Sources/FioriAR/ARCards/Views/Components/PickerSelectionView.swift
+++ b/Sources/FioriAR/ARCards/Views/Components/PickerSelectionView.swift
@@ -1,0 +1,27 @@
+//
+//  PickerSelectionView.swift
+//
+//
+//  Created by O'Brien, Patrick on 1/4/22.
+//
+
+import SwiftUI
+
+enum ImagePickerSource {
+    case camera
+    case photoLibrary
+}
+
+struct PickerSelectionView: View {
+    @Binding var uiImage: UIImage?
+    var imageSource: ImagePickerSource
+    
+    var body: some View {
+        switch imageSource {
+        case .camera:
+            ImageCameraPickerView(uiImage: $uiImage)
+        case .photoLibrary:
+            ImagePickerView(uiImage: $uiImage)
+        }
+    }
+}

--- a/Sources/FioriAR/Utils/UIImage+Extensions.swift
+++ b/Sources/FioriAR/Utils/UIImage+Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  UIImage+Extensions.swift
+//
+//
+//  Created by O'Brien, Patrick on 1/4/22.
+//
+
+import UIKit
+
+extension UIImage {
+    func resize(to percent: CGFloat) -> UIImage? {
+        let newSize = CGSize(width: self.size.width * percent, height: self.size.height * percent)
+        UIGraphicsBeginImageContextWithOptions(newSize, true, 1.0)
+        self.draw(in: CGRect(origin: .zero, size: newSize))
+        defer { UIGraphicsEndImageContext() }
+        return UIGraphicsGetImageFromCurrentImageContext()
+    }
+}


### PR DESCRIPTION
- Created Representable for PHPicker
- Wrapper View for Camera or PHPicker selection
- Simplified image bindings in camera and phpicker representables
- Made State vars private in CardFormView

We only select one image at a time. Perhaps observing for photo library changes is not required and checking authorization is not needed. Since phpicker is out of process and a single image selection is clear intent.

✅ Closes: #78