### PR TITLE
fix: 🐛 Fix color inconsistencies, finalized spec for CardView, MatchedScanView

### DIFF
--- a/Sources/FioriAR/ARCards/Views/AnchorDetection/ARScanView.swift
+++ b/Sources/FioriAR/ARCards/Views/AnchorDetection/ARScanView.swift
@@ -197,7 +197,7 @@ private struct ImageMatchedView: View {
             .foregroundColor(.white)
             .background(
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(Color(red: 0 / 255, green: 90 / 255, blue: 38 / 255, opacity: 0.6))
+                    .fill(Color(red: 37 / 255, green: 111 / 255, blue: 58 / 255, opacity: 0.6))
                     .frame(width: 120, height: 120)
                     .padding(.all, 3)
                     .background(

--- a/Sources/FioriAR/ARCards/Views/Card/CardView.swift
+++ b/Sources/FioriAR/ARCards/Views/Card/CardView.swift
@@ -44,7 +44,7 @@ extension Fiori {
             
             func body(content: Content) -> some View {
                 content
-                    .font(.body)
+                    .font(.fiori(forTextStyle: .body))
                     .foregroundColor(self.isSelected ? Color.preferredColor(.tintColor, background: .lightConstant) : .clear)
                     .lineLimit(1)
             }
@@ -194,7 +194,7 @@ public extension CardView {
                 .frame(width: 198, height: isSelected && !isActionTextNil ? 44 : 0)
         }
         .frame(width: 230)
-        .background(Color.preferredColor(.primaryGroupedBackground, background: .lightConstant))
+        .background(Color.preferredColor(.primaryBackground, background: .lightConstant))
         .cornerRadius(10)
         .shadow(color: Color.black.opacity(0.15), radius: 4, y: 2)
         .opacity(isSelected ? 1 : 0.8)
@@ -272,7 +272,7 @@ public struct DefaultIcon: View {
     public var body: some View {
         icon
             .font(.system(size: 37))
-            .foregroundColor(Color.preferredColor(.tertiaryLabel, background: .lightConstant))
+            .foregroundColor(Color.preferredColor(.quarternaryLabel, background: .lightConstant))
     }
 }
 


### PR DESCRIPTION
Noticed color/font inconsistencies when reviewing the final specs.

CardView Stencil:
https://www.figma.com/file/7kRWb9O0A2P2uyCOIAPCCM/Fiori-for-iOS-7.0---Stencil-v0.9?node-id=867%3A39522

AR Annotations Stencil:
https://www.figma.com/file/7kRWb9O0A2P2uyCOIAPCCM/Fiori-for-iOS-7.0---Stencil-v0.9?node-id=2452%3A92671